### PR TITLE
Override $mat-light-theme-background[card] to make light themes more comfortable/readable

### DIFF
--- a/plugin/app/src/assets/styles/theming-setup.scss
+++ b/plugin/app/src/assets/styles/theming-setup.scss
@@ -26,4 +26,7 @@
 	@include elevate-custom-theme($dark-theme);
 }
 
+// Improve comfort/readability of light themes by overriding card background to match app-bar
+$mat-light-theme-background: map-merge($mat-light-theme-background, (card: map_get($mat-grey, 100)));
+
 @import "./themes/all";


### PR DESCRIPTION
I find the light themes difficult to read, partly because the white card background is blindingly bright. 
 One approach for improving the readability of the light themes is to adjust the card background colour.

Alternatively, the mat-typography config could be modified to increase font-weights, which should make them more readable.
```
@function mat-typography-config(
  $font-family:   'Roboto, "Helvetica Neue", sans-serif',
  $display-4:     mat-typography-level(112px, 112px, 300),
  $display-3:     mat-typography-level(56px, 56px, 400),
  $display-2:     mat-typography-level(45px, 48px, 400),
  $display-1:     mat-typography-level(34px, 40px, 400),
  $headline:      mat-typography-level(24px, 32px, 400),
  $title:         mat-typography-level(20px, 32px, 500),
  $subheading-2:  mat-typography-level(16px, 28px, 400),
  $subheading-1:  mat-typography-level(15px, 24px, 400),
  $body-2:        mat-typography-level(14px, 24px, 500),
  $body-1:        mat-typography-level(14px, 20px, 400),
  $caption:       mat-typography-level(12px, 20px, 400),
  $button:        mat-typography-level(14px, 14px, 500),
  // Line-height must be unit-less fraction of the font-size.
  $input:         mat-typography-level(inherit, 1.125, 400)
) {

  // Declare an initial map with all of the levels.
  $config: (
    display-4:      $display-4,
    display-3:      $display-3,
    display-2:      $display-2,
    display-1:      $display-1,
    headline:       $headline,
    title:          $title,
    subheading-2:   $subheading-2,
    subheading-1:   $subheading-1,
    body-2:         $body-2,
    body-1:         $body-1,
    caption:        $caption,
    button:         $button,
    input:          $input,
  );
```